### PR TITLE
feat: user can cancel his vote by simply clicking the same icon

### DIFF
--- a/src/Components/Comment.js
+++ b/src/Components/Comment.js
@@ -32,7 +32,7 @@ const Comment = (props) => {
         const isAReply = !!replyingTo;
 
         if (props.data.vote === vote) {
-            dispatch(makeAVote("neutral", id, false));
+            dispatch(makeAVote("neutral", id, isAReply));
         } else {
             dispatch(makeAVote(vote, id, isAReply));
         }

--- a/src/Components/Comment.js
+++ b/src/Components/Comment.js
@@ -29,11 +29,13 @@ const Comment = (props) => {
         setEditing(false);
     }
     const handleVote = (vote) => {
-        if (props.data.vote) if (props.data.vote === vote) return;
+        const isAReply = !!replyingTo;
 
-        const isAReply = replyingTo ? true : false;
-        if (props.data.vote) if (props.data.vote !== vote) dispatch(makeAVote(vote, id, isAReply));
-        dispatch(makeAVote(vote, id, isAReply));
+        if (props.data.vote === vote) {
+            dispatch(makeAVote("neutral", id, false));
+        } else {
+            dispatch(makeAVote(vote, id, isAReply));
+        }
     }
 
     function handleKeyDown(e) {

--- a/src/Data/ReduxStore.js
+++ b/src/Data/ReduxStore.js
@@ -147,13 +147,13 @@ function CommentReducer(state = initial_state, action) {
 
                 // Inject modified reply into parent
                 originalComment.replies = originalComment.replies.map(reply => {
-                    if(reply.id !== id) return reply;
+                    if (reply.id !== id) return reply;
                     else return newReply
                 })
-                
+
                 // Inject modified parent into all comments
                 newComments = state.comments.map(comment => {
-                    if(comment.id !== originalComment.id) return comment;
+                    if (comment.id !== originalComment.id) return comment;
                     return originalComment
                 })
 
@@ -179,9 +179,11 @@ function CommentReducer(state = initial_state, action) {
         }
         case 'vote': {
             const { vote, id, isAReply } = action.payload;
+            const { vote: previousVote } = isAReply ? getReplyById(state.comments, id) : getCommentById(state.comments, id);
             let voteFunction;
             if (vote === 'up') voteFunction = (score) => score + 1;
             if (vote === 'down') voteFunction = (score) => score - 1;
+            if (vote === 'neutral') voteFunction = (score) => previousVote === 'up' ? score - 1 : score + 1;
             let newComments = [];
 
             if (isAReply) {

--- a/src/Data/ReduxStore.js
+++ b/src/Data/ReduxStore.js
@@ -181,8 +181,8 @@ function CommentReducer(state = initial_state, action) {
             const { vote, id, isAReply } = action.payload;
             const { vote: previousVote } = isAReply ? getReplyById(state.comments, id) : getCommentById(state.comments, id);
             let voteFunction;
-            if (vote === 'up') voteFunction = (score) => score + 1;
-            if (vote === 'down') voteFunction = (score) => score - 1;
+            if (vote === 'up') voteFunction = (score) => previousVote === 'down' ? score + 2 : score + 1;
+            if (vote === 'down') voteFunction = (score) => previousVote === 'up' ? score - 2 : score - 1;
             if (vote === 'neutral') voteFunction = (score) => previousVote === 'up' ? score - 1 : score + 1;
             let newComments = [];
 

--- a/src/Data/data.json
+++ b/src/Data/data.json
@@ -13,6 +13,7 @@
       "content": "Impressive! Though it seems the drag feature could be improved. But overall it looks incredible. You've nailed the design and the responsiveness at various breakpoints works really well.",
       "createdAt": "1 month ago",
       "score": 12,
+      "vote": "neutral",
       "user": {
         "image": {
           "png": "./images/avatars/image-amyrobson.png",
@@ -27,6 +28,7 @@
       "content": "Woah, your project looks awesome! How long have you been coding for? I'm still new, but think I want to dive into React as well soon. Perhaps you can give me an insight on where I can learn React? Thanks!",
       "createdAt": "2 weeks ago",
       "score": 5,
+      "vote": "neutral",
       "user": {
         "image": {
           "png": "./images/avatars/image-maxblagun.png",
@@ -40,6 +42,7 @@
           "content": "If you're still new, I'd recommend focusing on the fundamentals of HTML, CSS, and JS before considering React. It's very tempting to jump ahead but lay a solid foundation first.",
           "createdAt": "1 week ago",
           "score": 4,
+          "vote": "neutral",
           "replyingTo": "maxblagun",
           "user": {
             "image": {
@@ -54,6 +57,7 @@
           "content": "I couldn't agree more with this. Everything moves so fast and it always seems like everyone knows the newest library/framework. But the fundamentals are what stay constant.",
           "createdAt": "2 days ago",
           "score": 2,
+          "vote": "neutral",
           "replyingTo": "ramsesmiron",
           "user": {
             "image": {


### PR DESCRIPTION
# Why
It's kind of a default behavior in web, when i vote up something, I should be able to cancel it by re-clicking the same icon, also cleaned up the vote function in Comment.js, it looked confusing at first.

# New behavior

1. The votes are "neutral" by default (which is better than starting with null/undefined or other false values)
2. Once a vote is recorder, it's tested so if the vote was re-clicked, it turns the state back to neutral, otherwise it records the vote.
3. If the previous vote is the opposite of the current (was up, but then down) the state will manage that by using + 2 or -2, so user doesn't need an extra click (e.g. if he was up, he won't need to go to neutral then down).
